### PR TITLE
Remove user reaction after ticket create

### DIFF
--- a/SupportBoi/EventHandler.cs
+++ b/SupportBoi/EventHandler.cs
@@ -153,6 +153,9 @@ namespace SupportBoi
 			await ticketChannel.SendMessageAsync("Hello, " + member.Mention + "!\n" +
 			                                     Config.welcomeMessage);
 
+			// Remove user's reaction
+			await e.Message.DeleteReactionAsync(e.Emoji, e.User);
+
 			// Refreshes the channel as changes were made to it above
 			ticketChannel = await SupportBoi.GetClient().GetChannelAsync(ticketChannel.Id);
 
@@ -187,7 +190,7 @@ namespace SupportBoi
 					}
 				}
 			}
-			
+
 			// Log it if the log channel exists
 			DiscordChannel logChannel = guild.GetChannel(Config.logChannel);
 			if (logChannel != null)


### PR DESCRIPTION
I've seen numerous requests for this, so here it is

When a user opens a ticket by reaction, the reaction will now automatically be removed again.
This way users do not need to unreact before re-reacting when opening future tickets, preventing confusion